### PR TITLE
Draft: Compare feature/anthropic-mcp-integration with master

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,7 @@ REALTIME_VOICE_API_KEY=YOUR_REALTIME_VOICE_API_KEY_HERE
 # --- Ngrok Configuration (if used for exposing local server) ---
 NGROK_URL=YOUR_NGROK_URL_HERE
 NGROK_PORT=YOUR_NGROK_PORT_HERE
+
+# --- MCP Server Configuration ---
+# Used by the backend to communicate with the MCP server.
+MCP_SERVER_URL=http://localhost:5002

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ vcrpy>=4.0.0 # Added to ensure compatibility with urllib3 v2.x for pytest-record
 httpx
 langgraph
 langchain-openai
+mcp[server,cli]

--- a/tests/test_main_mcp_server.py
+++ b/tests/test_main_mcp_server.py
@@ -1,0 +1,281 @@
+import pytest
+import asyncio
+import httpx
+from unittest.mock import MagicMock, patch # AsyncMock might be needed if we mock async methods directly
+
+# MCP Client imports
+from mcp.client import ClientSession
+from mcp.client.transports.sse import sse_client_transport # Correct context manager for SSE
+from mcp.common.message import Message, MessageType
+from mcp.common.errors import MCPError, ToolError, RemoteError
+
+# Import the FastAPI app from main.py
+# We need to ensure environment variables are set before this import if main.py uses them at module level.
+# The fixture below will handle this.
+main_fastapi_app = None
+mcp_server_sse_path = None
+mcp_server_messages_path = None
+twilio_client_mock_path = 'main.twilio_client' # Path to twilio_client in main.py
+TwilioRestException_path = 'main.TwilioRestException' # Path to TwilioRestException in main.py
+# Path to the specific TwilioRestException class, assuming it's imported in main.py or accessible via main.
+# If main.py imports `from twilio.base.exceptions import TwilioRestException`, this path might need adjustment
+# or we import TwilioRestException directly in tests. For now, assume it's available via `main`.
+
+@pytest.fixture(scope="module")
+def event_loop():
+    """Create an instance of the default event loop for each test module."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+@pytest.fixture(scope="module", autouse=True)
+def set_env_vars(module_mocker):
+    """
+    Set necessary environment variables at the module level before main.py is imported.
+    Using module_mocker from pytest-mock if available, or monkeypatch.
+    This runs once per module.
+    """
+    # Using pytest-mock's module_mocker if specifically needed for module-level mocking before import.
+    # monkeypatch is function-scoped by default. For module scope, can define a module-scoped fixture.
+    # For simplicity, we'll assume direct monkeypatching in a module-scoped autouse fixture works,
+    # or rely on the fact that imports happen after fixture setup for session/module.
+    # Let's use a more standard way with monkeypatch if pytest-mock's module_mocker isn't standard.
+    # Pytest's monkeypatch can be used in module scope.
+    pass # Will be handled by http_client fixture's specific monkeypatching for now
+
+@pytest.fixture(scope="module")
+async def main_app_instance(monkeypatch_module):
+    """
+    Module-scoped fixture to set environment variables and import main.py components.
+    `monkeypatch_module` is a hypothetical way to get module-scoped monkeypatch.
+    Standard `monkeypatch` is function-scoped. We'll use a trick or ensure it's applied before import.
+    """
+    monkeypatch_module.setenv("CHAT_MODEL_API_KEY", "dummy_chat_api_key")
+    monkeypatch_module.setenv("TWILIO_ACCOUNT_SID", "dummy_twilio_sid")
+    monkeypatch_module.setenv("TWILIO_AUTH_TOKEN", "dummy_twilio_token")
+    monkeypatch_module.setenv("TWILIO_PHONE_NUMBER", "+15550001111")
+    monkeypatch_module.setenv("NGROK_URL", "test-ngrok.io") # For get_mcp_websocket_url
+
+    # Import after env vars are set
+    from main import app as real_app, MCP_SSE_PATH, MCP_MESSAGES_PATH
+    
+    global main_fastapi_app, mcp_server_sse_path, mcp_server_messages_path
+    main_fastapi_app = real_app
+    mcp_server_sse_path = MCP_SSE_PATH
+    mcp_server_messages_path = MCP_MESSAGES_PATH
+    
+    return main_fastapi_app
+
+@pytest.fixture
+async def http_client(main_app_instance):
+    """Provides an httpx.AsyncClient for the FastAPI app."""
+    # main_app_instance fixture ensures env vars are set and app is loaded.
+    async with httpx.AsyncClient(app=main_app_instance, base_url="http://testserver") as client:
+        yield client
+
+# --- Test Cases ---
+
+@pytest.mark.asyncio
+async def test_mcp_server_initialization_and_list_tools(http_client):
+    """
+    Tests that the MCP server initializes and lists the 'initiate_call_mcp_tool'.
+    """
+    sse_url = f"{http_client.base_url}{mcp_server_sse_path}"
+    messages_url = f"{http_client.base_url}{mcp_server_messages_path}"
+
+    # The sse_client_transport needs the http_client to route its internal requests
+    # to our test app. We achieve this by passing the client to the transport.
+    async with sse_client_transport(
+        uri=sse_url, 
+        post_uri=messages_url, 
+        client=http_client # Pass the test client
+    ) as (reader, writer):
+        async with ClientSession(reader, writer, name="test-client") as session:
+            await session.initialize(capabilities={}) # Must initialize session
+            
+            tools = await session.list_tools()
+            assert isinstance(tools, list)
+            
+            found_tool = False
+            for tool in tools:
+                if tool.name == "initiate_call_mcp_tool":
+                    found_tool = True
+                    assert "Initiates an outbound call using Twilio" in tool.description
+                    assert tool.parameters is not None
+                    param_names = {p.name for p in tool.parameters.properties}
+                    expected_params = {"target_phone_number", "task_instruction", "call_context"}
+                    assert param_names == expected_params
+                    # Further checks for parameter types could be added if MCP schema provides them
+                    # e.g., checking tool.parameters.properties['target_phone_number'].type == 'string'
+                    break
+            assert found_tool, "Tool 'initiate_call_mcp_tool' not found."
+
+@pytest.mark.asyncio
+async def test_mcp_call_initiate_call_tool_success(http_client, mocker):
+    """
+    Tests successful invocation of the 'initiate_call_mcp_tool'.
+    """
+    sse_url = f"{http_client.base_url}{mcp_server_sse_path}"
+    messages_url = f"{http_client.base_url}{mcp_server_messages_path}"
+
+    # Mock twilio_client.calls.create in main.py
+    mock_twilio_call_create = mocker.patch(f"{twilio_client_mock_path}.calls.create")
+    expected_call_sid = "CA1234567890abcdef1234567890abcd"
+    mock_twilio_call_create.return_value = MagicMock(sid=expected_call_sid)
+
+    async with sse_client_transport(uri=sse_url, post_uri=messages_url, client=http_client) as (reader, writer):
+        async with ClientSession(reader, writer, name="test-client-success") as session:
+            await session.initialize(capabilities={})
+            
+            tool_params = {
+                "target_phone_number": "+15551234567",
+                "task_instruction": "Test task: call the number.",
+                "call_context": {"customer_id": "CUST001", "priority": "high"}
+            }
+            result = await session.call_tool("initiate_call_mcp_tool", tool_params)
+            
+            assert result is not None
+            assert result.get("status") == "Call initiated"
+            assert result.get("call_sid") == expected_call_sid
+
+            # Assert that twilio_client.calls.create was called correctly
+            # asyncio.to_thread means the mock is on the sync method
+            mock_twilio_call_create.assert_called_once()
+            call_args = mock_twilio_call_create.call_args
+            assert call_args is not None
+            assert call_args.kwargs['to'] == tool_params["target_phone_number"]
+            # TWILIO_PHONE_NUMBER is used from env, check it if needed or trust main.py's logic
+            assert "twiml" in call_args.kwargs
+            # Further TwiML content assertions could be added if necessary
+
+@pytest.mark.asyncio
+async def test_mcp_call_initiate_call_tool_twilio_error(http_client, mocker):
+    """
+    Tests error handling when Twilio client raises an exception.
+    """
+    sse_url = f"{http_client.base_url}{mcp_server_sse_path}"
+    messages_url = f"{http_client.base_url}{mcp_server_messages_path}"
+
+    # Import TwilioRestException directly for use in the test
+    from twilio.base.exceptions import TwilioRestException
+
+    # Mock twilio_client.calls.create to raise TwilioRestException
+    mock_twilio_call_create = mocker.patch(f"{twilio_client_mock_path}.calls.create")
+    twilio_error_message = "Simulated Twilio API error"
+    mock_twilio_call_create.side_effect = TwilioRestException(
+        status=500, uri="/Calls", msg=twilio_error_message
+    )
+
+    async with sse_client_transport(uri=sse_url, post_uri=messages_url, client=http_client) as (reader, writer):
+        async with ClientSession(reader, writer, name="test-client-twilio-error") as session:
+            await session.initialize(capabilities={})
+            
+            tool_params = {
+                "target_phone_number": "+15557654321",
+                "task_instruction": "Test Twilio error scenario.",
+                "call_context": {}
+            }
+            
+            with pytest.raises(RemoteError) as exc_info: # MCP client should raise RemoteError for tool errors
+                await session.call_tool("initiate_call_mcp_tool", tool_params)
+            
+            assert exc_info.value is not None
+            # The error message from the tool (via FastMCP) might be wrapped.
+            # Check if the original Twilio message is part of the error details.
+            # FastMCP typically wraps the original exception message.
+            assert twilio_error_message in str(exc_info.value.message)
+            # Or if FastMCP has a more structured error, check its fields.
+            # For example, if exc_info.value.data has more details.
+
+@pytest.mark.asyncio
+async def test_mcp_call_initiate_call_tool_validation_error(http_client, mocker):
+    """
+    Tests error handling for input validation errors in the MCP tool.
+    """
+    sse_url = f"{http_client.base_url}{mcp_server_sse_path}"
+    messages_url = f"{http_client.base_url}{mcp_server_messages_path}"
+
+    # No need to mock Twilio here as validation should happen first.
+    # However, ensure the mock is in place if any call could still reach it.
+    mocker.patch(f"{twilio_client_mock_path}.calls.create", new_callable=MagicMock)
+
+
+    async with sse_client_transport(uri=sse_url, post_uri=messages_url, client=http_client) as (reader, writer):
+        async with ClientSession(reader, writer, name="test-client-validation-error") as session:
+            await session.initialize(capabilities={})
+            
+            # Test case 1: Empty task_instruction
+            invalid_params_empty_instruction = {
+                "target_phone_number": "+15551234567",
+                "task_instruction": "", # Empty instruction
+                "call_context": {}
+            }
+            with pytest.raises(RemoteError) as exc_info_empty:
+                await session.call_tool("initiate_call_mcp_tool", invalid_params_empty_instruction)
+            assert "task_instruction parameter cannot be empty" in str(exc_info_empty.value.message).lower()
+
+            # Test case 2: Invalid phone number
+            invalid_params_bad_phone = {
+                "target_phone_number": "12345", # Invalid format
+                "task_instruction": "Valid instruction here.",
+                "call_context": {}
+            }
+            with pytest.raises(RemoteError) as exc_info_phone:
+                await session.call_tool("initiate_call_mcp_tool", invalid_params_bad_phone)
+            assert "invalid target_phone_number format" in str(exc_info_phone.value.message).lower()
+
+# Note: The monkeypatch_module fixture for module-scoped monkeypatching is a bit conceptual.
+# A common way is to use a top-level conftest.py or ensure fixtures that need module scope
+# are defined correctly. For this single file, the `main_app_instance` fixture tries to achieve this.
+# If `main.py`'s imports are sensitive at the exact moment of `from main import app`,
+# this setup might need adjustment, e.g. by moving env var setup to a session-start hook
+# or ensuring `main.py` is structured to allow config overrides after import for testing.
+# For now, assuming `main_app_instance` correctly handles pre-import setup.
+
+# Need to provide `monkeypatch_module` if it's not a built-in pytest fixture.
+# Standard pytest `monkeypatch` is function-scoped. For module scope, we can define it like this:
+@pytest.fixture(scope="module")
+def monkeypatch_module(request):
+    from _pytest.monkeypatch import MonkeyPatch
+    mpatch = MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
+```
+
+Some notes on the generated code:
+- The `sse_client_transport` from `mcp.client.transports.sse` is the correct context manager. I've added `client=http_client` to its arguments, assuming it can take an `httpx.AsyncClient` to route its requests. This is crucial for testing against an in-memory FastAPI app. If this specific way of passing the client is not supported by `sse_client_transport`, this part might need adjustment (e.g., using `respx` or a similar library if `sse_client_transport` makes its own top-level `httpx` calls).
+- Mocking paths for Twilio client (`twilio_client_mock_path`) are defined.
+- The `main_app_instance` fixture now uses `monkeypatch_module` (a manually defined module-scoped monkeypatch) to set environment variables *before* importing `main.py` components. This is critical if `main.py` reads env vars at the module level.
+- `TwilioRestException` is imported directly in the relevant test for clarity and to ensure it's the correct type.
+- Assertions for errors now check for `RemoteError` from `mcp.common.errors`, as this is what `FastMCP` and `ClientSession` typically convert tool execution errors into. The original error message is expected to be part of `exc_info.value.message`.
+- Parameter validation tests check for parts of the expected error messages.
+
+This structure seems like a good starting point. I'll proceed with these tests.Okay, I have created the content for `tests/test_main_mcp_server.py`.
+This includes:
+1.  **Imports**: `pytest`, `asyncio`, `httpx`, `ClientSession`, `sse_client_transport` from `mcp.client.transports.sse`, `Message`, `MessageType`, `MCPError`, `ToolError`, `RemoteError` from `mcp.common`, and mock utilities.
+2.  **Fixtures**:
+    *   `event_loop`: Standard fixture for asyncio tests.
+    *   `monkeypatch_module`: A module-scoped version of `monkeypatch`.
+    *   `main_app_instance`: A module-scoped fixture that uses `monkeypatch_module` to set necessary environment variables (`CHAT_MODEL_API_KEY`, Twilio credentials, `NGROK_URL`) *before* importing `app`, `MCP_SSE_PATH`, and `MCP_MESSAGES_PATH` from `main.py`. This ensures that `main.py` initializes correctly with dummy credentials for testing.
+    *   `http_client`: An async fixture that provides an `httpx.AsyncClient` instance configured with the `main_fastapi_app` (obtained from `main_app_instance`) and a base URL of `http://testserver`.
+3.  **Test Cases**:
+    *   **`test_mcp_server_initialization_and_list_tools`**:
+        *   Connects to the MCP server using `sse_client_transport`, passing the `http_client` to ensure requests are routed to the test app.
+        *   Initializes a `ClientSession`.
+        *   Calls `session.list_tools()` and asserts that `initiate_call_mcp_tool` is listed with its correct description and parameters.
+    *   **`test_mcp_call_initiate_call_tool_success`**:
+        *   Mocks `main.twilio_client.calls.create` to return a successful call object with a `sid`.
+        *   Connects via SSE, initializes a session, and calls `initiate_call_mcp_tool` with valid parameters.
+        *   Asserts the success response from the tool and that the Twilio mock was called with correct arguments.
+    *   **`test_mcp_call_initiate_call_tool_twilio_error`**:
+        *   Mocks `main.twilio_client.calls.create` to raise a `TwilioRestException`.
+        *   Connects and calls the tool.
+        *   Asserts that a `RemoteError` is raised by the MCP client and that the error message contains details of the Twilio failure.
+    *   **`test_mcp_call_initiate_call_tool_validation_error`**:
+        *   Connects and calls the tool with invalid inputs (empty `task_instruction`, invalid `target_phone_number`).
+        *   Asserts that a `RemoteError` is raised for each validation failure and that the error message reflects the specific validation problem.
+
+This set of tests covers the initialization, tool listing, successful tool execution, and error handling (both external dependency errors and input validation errors) for the MCP server functionality in `main.py`.
+The crucial part for these tests to work is the correct interaction between the `sse_client_transport` and the `http_client` fixture. The code assumes `sse_client_transport` can use the provided `http_client` for its underlying HTTP requests, which is a common pattern for testability in such SDKs.
+
+I will now submit the subtask report.

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,340 @@
+import pytest
+import httpx # For ConnectError
+from httpx import AsyncClient # For test client
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from types import SimpleNamespace # For yielding multiple objects from fixture
+
+# MCP Client related imports for mocking and error types
+from mcp.common.errors import MCPError, ToolError, ClientError
+# CallInitiationRequest will be provided by the app_env_fixture
+
+# Target URL for MCP server (used by app code, set via env var in fixture)
+TARGET_MCP_URL = "http://mocked-mcp-server:1234" # Matches what app_env_fixture sets
+
+@pytest.fixture(name="app_env_fixture", scope="function", autouse=True)
+def fixture_reset_app_module_and_mock_env(mocker):
+    """
+    Fixture to ensure each test gets a fresh app import with specific env mocks.
+    This isolates tests, especially for module-level configurations.
+    It yields the app instance and CallInitiationRequest model.
+    """
+    import sys
+
+    # Mock os.getenv *before* importing the app module.
+    # Ensures MCP_SERVER_URL is set to TARGET_MCP_URL for the app's context.
+    mocker.patch('os.getenv', lambda key, default=None: TARGET_MCP_URL if key == "MCP_SERVER_URL" else ("dummy_openai_key" if key == "OPENAI_API_KEY" else default))
+
+    modules_to_reload = [
+        'backend.web.app',
+        'backend.agent.workflow_manager',
+        'backend.web.call_handler_models'
+    ]
+    for module_name in modules_to_reload:
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+    
+    from backend.web.app import app as fresh_app, MCP_SERVER_BASE_URL, DEFAULT_MCP_SERVER_URL
+    from backend.web.call_handler_models import CallInitiationRequest as FreshCallInitiationRequest
+        
+    assert MCP_SERVER_BASE_URL == TARGET_MCP_URL, \
+        f"MCP_SERVER_BASE_URL was {MCP_SERVER_BASE_URL}, expected {TARGET_MCP_URL}. Check os.getenv mock."
+
+    yield SimpleNamespace(app=fresh_app, CallInitiationRequest=FreshCallInitiationRequest)
+
+    for module_name in modules_to_reload:
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
+# --- Kept Tests for MCP_SERVER_URL warning ---
+@pytest.mark.asyncio
+async def test_mcp_url_default_warning(mocker, caplog, app_env_fixture):
+    """
+    Test that a warning is logged if MCP_SERVER_URL is not set and the default is used.
+    This test re-imports app with specific os.getenv mocking.
+    """
+    import sys
+    
+    if 'backend.web.app' in sys.modules:
+        del sys.modules['backend.web.app']
+
+    mocker.patch('os.getenv', lambda key, default=None: default if key == "MCP_SERVER_URL" else "dummy_key_for_other_configs")
+    
+    from backend.web.app import app as new_app_instance, DEFAULT_MCP_SERVER_URL # app import triggers the log
+    
+    found_warning = False
+    for record in caplog.records:
+        if record.levelname == "WARNING" and f"MCP_SERVER_URL not set, using default: {DEFAULT_MCP_SERVER_URL}" in record.message:
+            found_warning = True
+            break
+    assert found_warning, "Warning for default MCP_SERVER_URL not logged."
+
+    if 'backend.web.app' in sys.modules:
+        del sys.modules['backend.web.app']
+    # Fixture will reset for next test
+
+def test_mcp_url_default_warning_check_url_and_log(mocker, caplog, app_env_fixture):
+    """
+    Test that MCP_SERVER_BASE_URL is set to default when env var is missing,
+    and a warning is logged. (Alternative way to test the warning)
+    """
+    import sys
+    if 'backend.web.app' in sys.modules:
+        del sys.modules['backend.web.app'] 
+
+    mocker.patch('os.getenv', lambda key, default=None: default if key == "MCP_SERVER_URL" else ("dummy_openai_key" if key == "OPENAI_API_KEY" else default))
+    
+    from backend.web.app import app as app_for_warning_test, MCP_SERVER_BASE_URL, DEFAULT_MCP_SERVER_URL, logger
+    
+    assert MCP_SERVER_BASE_URL == DEFAULT_MCP_SERVER_URL
+    
+    found_warning = False
+    for record in caplog.records:
+        if record.name == logger.name and record.levelname == "WARNING" and \
+           f"MCP_SERVER_URL not set, using default: {DEFAULT_MCP_SERVER_URL}" in record.message:
+            found_warning = True
+            break
+    assert found_warning, f"Warning for default MCP_SERVER_URL not logged by logger '{logger.name}'. Log records: {caplog.text}"
+
+    if 'backend.web.app' in sys.modules:
+        del sys.modules['backend.web.app']
+    # Fixture will reset for next test
+
+# --- New Test Cases for /mcp/initiate_call ---
+
+@pytest.mark.asyncio
+async def test_mcp_initiate_call_success(mocker, app_env_fixture):
+    """Test successful call to /mcp/initiate_call endpoint."""
+    
+    mock_sse_transport = mocker.patch('backend.web.app.sse_client_transport', autospec=True)
+    mock_reader = AsyncMock()
+    mock_writer = AsyncMock()
+    mock_sse_transport.return_value.__aenter__.return_value = (mock_reader, mock_writer)
+
+    mock_client_session_instance = AsyncMock()
+    mock_client_session_instance.initialize = AsyncMock()
+    expected_tool_result = {"status": "Call initiated by MCP", "call_sid": "CS_MCP_123"}
+    mock_client_session_instance.call_tool = AsyncMock(return_value=expected_tool_result)
+
+    mock_client_session_class = mocker.patch('backend.web.app.mcp.client.ClientSession', autospec=True)
+    mock_client_session_class.return_value.__aenter__.return_value = mock_client_session_instance
+
+    payload = app_env_fixture.CallInitiationRequest(
+        target_phone_number="+15551234567",
+        task_instruction="Test instruction",
+        call_context={"detail": "some_context"}
+    ).model_dump()
+
+    async with AsyncClient(app=app_env_fixture.app, base_url="http://testserver") as ac:
+        response = await ac.post("/mcp/initiate_call", json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == expected_tool_result
+
+    expected_sse_url = f"{TARGET_MCP_URL}/mcp/sse"
+    expected_messages_url = f"{TARGET_MCP_URL}/mcp/messages"
+    mock_sse_transport.assert_called_once_with(uri=expected_sse_url, post_uri=expected_messages_url)
+    
+    mock_client_session_class.assert_called_once_with(mock_reader, mock_writer, name="fastapi-mcp-client")
+    mock_client_session_instance.initialize.assert_called_once_with(capabilities={})
+    mock_client_session_instance.call_tool.assert_called_once_with(
+        "initiate_call_mcp_tool",
+        {
+            "target_phone_number": payload["target_phone_number"],
+            "task_instruction": payload["task_instruction"],
+            "call_context": payload["call_context"]
+        }
+    )
+
+@pytest.mark.asyncio
+async def test_mcp_initiate_call_tool_error(mocker, app_env_fixture):
+    """Test handling of ToolError from MCP client."""
+    mock_sse_transport = mocker.patch('backend.web.app.sse_client_transport', autospec=True)
+    mock_reader, mock_writer = AsyncMock(), AsyncMock()
+    mock_sse_transport.return_value.__aenter__.return_value = (mock_reader, mock_writer)
+
+    mock_client_session_instance = AsyncMock()
+    mock_client_session_instance.initialize = AsyncMock()
+    tool_error_msg = "Tool failed due to invalid input"
+    mock_client_session_instance.call_tool = AsyncMock(side_effect=ToolError(message=tool_error_msg, code="tool.input_validation_error"))
+    
+    mock_client_session_class = mocker.patch('backend.web.app.mcp.client.ClientSession', autospec=True)
+    mock_client_session_class.return_value.__aenter__.return_value = mock_client_session_instance
+
+    payload = app_env_fixture.CallInitiationRequest(
+        target_phone_number="+15551234567",
+        task_instruction="Test instruction for tool error",
+        call_context={}
+    ).model_dump()
+
+    async with AsyncClient(app=app_env_fixture.app, base_url="http://testserver") as ac:
+        response = await ac.post("/mcp/initiate_call", json=payload)
+
+    assert response.status_code == 400 # As per app.py logic for ToolError with this code
+    assert tool_error_msg in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_mcp_initiate_call_connection_error(mocker, app_env_fixture):
+    """Test handling of connection error when connecting to MCP server via SSE."""
+    # Mock sse_client_transport to raise ConnectError
+    # The sse_client_transport itself is an async context manager.
+    # So, its __aenter__ can raise the error, or the call to it if it's not a direct context manager.
+    # Based on its usage `async with sse_client_transport(...)`, its __aenter__ is what we target.
+    mock_sse_transport = mocker.patch('backend.web.app.sse_client_transport', autospec=True)
+    connect_error_msg = "Simulated connection refused"
+    mock_sse_transport.return_value.__aenter__.side_effect = httpx.ConnectError(connect_error_msg)
+
+    payload = app_env_fixture.CallInitiationRequest(
+        target_phone_number="+15551234567",
+        task_instruction="Test instruction for connection error",
+        call_context={}
+    ).model_dump()
+
+    async with AsyncClient(app=app_env_fixture.app, base_url="http://testserver") as ac:
+        response = await ac.post("/mcp/initiate_call", json=payload)
+    
+    assert response.status_code == 503 # Service Unavailable
+    assert "Could not connect to MCP server" in response.json()["detail"]
+    assert connect_error_msg in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_initiate_call_client_error_on_initialize(mocker, app_env_fixture):
+    """Test handling of MCP ClientError during session initialization."""
+    mock_sse_transport = mocker.patch('backend.web.app.sse_client_transport', autospec=True)
+    mock_reader, mock_writer = AsyncMock(), AsyncMock()
+    mock_sse_transport.return_value.__aenter__.return_value = (mock_reader, mock_writer)
+
+    mock_client_session_instance = AsyncMock()
+    client_error_msg = "Session initialization failed"
+    mock_client_session_instance.initialize = AsyncMock(side_effect=ClientError(message=client_error_msg, code="session.initialization_failed"))
+    
+    mock_client_session_class = mocker.patch('backend.web.app.mcp.client.ClientSession', autospec=True)
+    mock_client_session_class.return_value.__aenter__.return_value = mock_client_session_instance
+
+    payload = app_env_fixture.CallInitiationRequest(
+        target_phone_number="+15551234567",
+        task_instruction="Test instruction for client error",
+        call_context={}
+    ).model_dump()
+
+    async with AsyncClient(app=app_env_fixture.app, base_url="http://testserver") as ac:
+        response = await ac.post("/mcp/initiate_call", json=payload)
+    
+    # Based on app.py error handling for ClientError (maps to 503 or 500)
+    assert response.status_code == 503 # Or 500 if code isn't specific like connection
+    assert client_error_msg in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_mcp_initiate_call_generic_mcp_error(mocker, app_env_fixture):
+    """Test handling of a generic MCPError from the client session."""
+    mock_sse_transport = mocker.patch('backend.web.app.sse_client_transport', autospec=True)
+    mock_reader, mock_writer = AsyncMock(), AsyncMock()
+    mock_sse_transport.return_value.__aenter__.return_value = (mock_reader, mock_writer)
+
+    mock_client_session_instance = AsyncMock()
+    mcp_error_msg = "A generic MCP processing error occurred"
+    # Simulate error during call_tool, after initialize succeeds
+    mock_client_session_instance.initialize = AsyncMock() 
+    mock_client_session_instance.call_tool = AsyncMock(side_effect=MCPError(message=mcp_error_msg, code="mcp.processing_error"))
+    
+    mock_client_session_class = mocker.patch('backend.web.app.mcp.client.ClientSession', autospec=True)
+    mock_client_session_class.return_value.__aenter__.return_value = mock_client_session_instance
+
+    payload = app_env_fixture.CallInitiationRequest(
+        target_phone_number="+15551234567",
+        task_instruction="Test instruction for generic MCP error",
+        call_context={}
+    ).model_dump()
+
+    async with AsyncClient(app=app_env_fixture.app, base_url="http://testserver") as ac:
+        response = await ac.post("/mcp/initiate_call", json=payload)
+    
+    assert response.status_code == 500 # As per app.py logic for generic MCPError
+    assert mcp_error_msg in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_mcp_initiate_call_unexpected_tool_result_type(mocker, app_env_fixture):
+    """Test handling when MCP tool returns an unexpected data type."""
+    mock_sse_transport = mocker.patch('backend.web.app.sse_client_transport', autospec=True)
+    mock_reader, mock_writer = AsyncMock(), AsyncMock()
+    mock_sse_transport.return_value.__aenter__.return_value = (mock_reader, mock_writer)
+
+    mock_client_session_instance = AsyncMock()
+    mock_client_session_instance.initialize = AsyncMock()
+    # Simulate tool returning a string instead of a dict
+    mock_client_session_instance.call_tool = AsyncMock(return_value="this is not a dict")
+    
+    mock_client_session_class = mocker.patch('backend.web.app.mcp.client.ClientSession', autospec=True)
+    mock_client_session_class.return_value.__aenter__.return_value = mock_client_session_instance
+
+    payload = app_env_fixture.CallInitiationRequest(
+        target_phone_number="+15551234567",
+        task_instruction="Test instruction for unexpected result",
+        call_context={}
+    ).model_dump()
+
+    async with AsyncClient(app=app_env_fixture.app, base_url="http://testserver") as ac:
+        response = await ac.post("/mcp/initiate_call", json=payload)
+    
+    assert response.status_code == 500 
+    assert "MCP tool returned unexpected data type" in response.json()["detail"]
+
+```
+The previous tests for `/initiate-call-mcp` have been removed and replaced with new tests for the `/mcp/initiate_call` endpoint.
+The new tests cover:
+-   Successful tool call via MCP SSE client.
+-   Handling of `ToolError` from the MCP client.
+-   Handling of `httpx.ConnectError` when `sse_client_transport` tries to connect.
+-   Handling of `ClientError` during `session.initialize`.
+-   Handling of generic `MCPError`.
+-   Handling of unexpected result types from `call_tool`.
+
+The `app_env_fixture` is used to set up the test app and provide `CallInitiationRequest`.
+Mocks are targeted at `backend.web.app.sse_client_transport` and `backend.web.app.mcp.client.ClientSession` as these are the modules/classes used by the application code being tested.
+
+The `TARGET_MCP_URL` is defined and used by the fixture to set the `MCP_SERVER_URL` environment variable, which the application code then uses to construct SSE URLs. The tests also use `TARGET_MCP_URL` to verify that `sse_client_transport` is called with the correct derived URLs.
+
+This comprehensive suite should cover the new MCP client logic in `backend/web/app.py`.I have generated the updated `tests/test_web_app.py` content.
+
+Here's a summary of the changes implemented in the generated code:
+
+1.  **Removed Old Tests**: Test functions related to the old `/initiate-call-mcp` endpoint (e.g., `test_initiate_call_mcp_success`, `test_initiate_call_mcp_server_error`, etc.) were removed.
+2.  **Kept Relevant Tests**: The tests `test_mcp_url_default_warning` and `test_mcp_url_default_warning_check_url_and_log` were kept as they test the `MCP_SERVER_URL` environment variable handling, which is still relevant.
+3.  **Added Imports**:
+    *   `unittest.mock.patch`, `AsyncMock`, `MagicMock`.
+    *   `mcp.common.errors.MCPError`, `ToolError`, `ClientError`.
+    *   `httpx` (for `ConnectError` and `AsyncClient`).
+    *   `types.SimpleNamespace`.
+    *   `CallInitiationRequest` is provided by the `app_env_fixture`.
+4.  **Fixture (`app_env_fixture`)**:
+    *   The existing fixture (previously `fixture_reset_app_module_and_mock_env`) was kept and is named `app_env_fixture`.
+    *   It correctly mocks `os.getenv` to set `MCP_SERVER_URL` to `TARGET_MCP_URL` for the application's context.
+    *   It handles the reloading of `backend.web.app` and `backend.web.call_handler_models` to ensure fresh imports for each test.
+    *   It yields a `SimpleNamespace` containing the `app` instance and the `CallInitiationRequest` model.
+5.  **New Test Cases for `/mcp/initiate_call`**:
+    *   **`test_mcp_initiate_call_success`**:
+        *   Mocks `backend.web.app.sse_client_transport` to simulate a successful SSE connection setup.
+        *   Mocks `backend.web.app.mcp.client.ClientSession` to simulate successful session initialization and a successful `call_tool` invocation.
+        *   Makes a POST request to `/mcp/initiate_call` with a valid payload.
+        *   Asserts a 200 status code and the expected JSON response.
+        *   Verifies that `sse_client_transport`, `session.initialize`, and `session.call_tool` were called with the correct parameters.
+    *   **`test_mcp_initiate_call_tool_error`**:
+        *   Sets up mocks similarly, but `session.call_tool` is configured to raise a `ToolError`.
+        *   Asserts that the endpoint returns the appropriate HTTP status code (400, based on `app.py`'s handling of `ToolError` with code `tool.input_validation_error`) and error detail.
+    *   **`test_mcp_initiate_call_connection_error`**:
+        *   Mocks `backend.web.app.sse_client_transport` (specifically its `__aenter__` method) to raise an `httpx.ConnectError`.
+        *   Asserts that the endpoint returns a 503 status code and an error message indicating failure to connect to the MCP server.
+    *   **`test_mcp_initiate_call_client_error_on_initialize`**:
+        *   Mocks `session.initialize` to raise a `ClientError`.
+        *   Asserts an appropriate HTTP status code (503, based on `app.py`'s handling) and error detail.
+    *   **`test_mcp_initiate_call_generic_mcp_error`**:
+        *   Mocks `session.call_tool` to raise a generic `MCPError`.
+        *   Asserts a 500 status code and error detail.
+    *   **`test_mcp_initiate_call_unexpected_tool_result_type`**:
+        *   Mocks `session.call_tool` to return a string instead of the expected dictionary.
+        *   Asserts a 500 status code and error detail indicating the type mismatch, as handled in `app.py`.
+
+All new asynchronous test functions are marked with `@pytest.mark.asyncio`. The mocking paths correctly target where the components are used within `backend.web.app`.
+
+The file `tests/test_web_app.py` now contains a relevant suite of tests for the updated MCP client functionality.


### PR DESCRIPTION
This is a draft pull request created to compare the feature/anthropic-mcp-integration branch with the master branch.

## Summary by Sourcery

Integrate an MCP server into the application to expose a call-initiation tool via SSE, and wire up a client endpoint to call that tool from the web service, complete with async handling, validation, logging, and tests.

New Features:
- Initialize FastMCP server in main.py and register an ‘initiate_call_mcp_tool’ for outbound Twilio calls
- Add a new FastAPI endpoint (/mcp/initiate_call) in backend/web/app.py to invoke the MCP tool over SSE

Enhancements:
- Use asyncio.to_thread for non-blocking Twilio SDK calls in handle_order and the MCP tool
- Rename and consolidate WebSocket URL helper for FastAPI usage
- Add configurable MCP server URL with default fallback and warning log

Build:
- Introduce mcp[server,cli] dependency in requirements.txt

Tests:
- Add comprehensive async tests for the new /mcp/initiate_call endpoint
- Add integration tests for the FastMCP server tools, including list_tools, success and various error scenarios